### PR TITLE
update version constraint in composer json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "library",
     "require": {
         "php":                           ">=5.3.0",
-        "antoligy/dom-string-iterators": "v1.0.0",
+        "antoligy/dom-string-iterators": "^v1.0.0",
         "twig/twig":                     ">=v1.0.0"
     },
     "license": "MIT",


### PR DESCRIPTION
the fixed constraint to v1.0.0 in antoligy/dom-string-iterators leads to an error on composer install
This PR loosens the constraint and makes it installable again